### PR TITLE
Fixes pathnames for data files

### DIFF
--- a/Day 5 Pandas/pandas.ipynb
+++ b/Day 5 Pandas/pandas.ipynb
@@ -120,9 +120,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget https://github.com/Milan-Chicago/Introduction-to-Python/blob/main/Day%205/wnba-team-elo-ratings.csv\n",
-    "!wget https://github.com/Milan-Chicago/Introduction-to-Python/blob/main/Day%205/pigeonRacing.txt\n",
-    "!wget https://github.com/Milan-Chicago/Introduction-to-Python/blob/main/Day%205/zoo.xlsx"
+    "!wget https://github.com/Milan-Chicago/Introduction-to-Python/blob/main/Day%205%20Pandas/wnba-team-elo-ratings.csv\n",
+    "!wget https://github.com/Milan-Chicago/Introduction-to-Python/blob/main/Day%205%20Pandas/pigeonRacing.txt\n",
+    "!wget https://github.com/Milan-Chicago/Introduction-to-Python/blob/main/Day%205%20Pandas/zoo.xlsx"
    ]
   },
   {


### PR DESCRIPTION
Files cannot be found with the current URLs:

![image](https://github.com/Milan-Chicago/Introduction-to-Python/assets/73510738/a0e539ee-0658-4f3d-a96d-3359f8a9cff8)

Updated pathnames for data files:

![image](https://github.com/Milan-Chicago/Introduction-to-Python/assets/73510738/18ba2b2b-6aa4-4f56-ba2e-e743d73f70a0)